### PR TITLE
`SlurmRunner` proof-of-concept

### DIFF
--- a/dask_hpc_runner/__init__.py
+++ b/dask_hpc_runner/__init__.py
@@ -1,2 +1,3 @@
 from .base import AsyncCommWorld, AsyncRunner  # noqa
 from .mpi import MPIRunner
+from .slurm import SlurmRunner

--- a/dask_hpc_runner/base.py
+++ b/dask_hpc_runner/base.py
@@ -156,7 +156,8 @@ class BaseRunner(SyncMethodMixin):
             sys.exit(0)
         elif self.role == Role.client:
             self.scheduler_address = await self.get_scheduler_address()
-            self.scheduler_comm = rpc(self.scheduler_address)
+            if self.scheduler_address:
+                self.scheduler_comm = rpc(self.scheduler_address)
             await self.before_client_start()
         self.status = Status.running
 
@@ -179,8 +180,9 @@ class BaseRunner(SyncMethodMixin):
     async def _close(self) -> None:
         print(f"stopping {self.role}")
         if self.status == Status.running:
-            with suppress(CommClosedError):
-                await self.scheduler_comm.terminate()
+            if self.scheduler_comm:
+                with suppress(CommClosedError):
+                    await self.scheduler_comm.terminate()
             self.status = Status.closed
 
     def close(self) -> None:

--- a/dask_hpc_runner/conftest.py
+++ b/dask_hpc_runner/conftest.py
@@ -24,3 +24,7 @@ def mpirun(allow_run_as_root):
         return ["mpirun", "--allow-run-as-root"]
     else:
         return ["mpirun"]
+
+@pytest.fixture
+def srun():
+    return ["srun", "--mpi=none"]

--- a/dask_hpc_runner/slurm.py
+++ b/dask_hpc_runner/slurm.py
@@ -81,10 +81,17 @@ class SlurmRunner(BaseRunner):
     async def before_worker_start(self) -> None:
         while not self.scheduler_file.exists():
             await asyncio.sleep(0.2)
+        self.load_scheduler_address()
 
     async def before_client_start(self) -> None:
         while not self.scheduler_file.exists():
             await asyncio.sleep(0.2)
+        self.load_scheduler_address()
+
+    def load_scheduler_address(self):
+        with self.scheduler_file.open() as f:
+            cfg = json.load(f)
+        self.scheduler_address = cfg["address"]
 
     async def get_worker_name(self) -> str:
         return self.rank

--- a/dask_hpc_runner/slurm.py
+++ b/dask_hpc_runner/slurm.py
@@ -1,0 +1,142 @@
+import atexit
+import os
+import sys
+
+import dask
+from dask.distributed import Scheduler
+from .base import Role, BaseRunner
+
+_RUNNER_REF = None
+
+
+class WorldTooSmallException(RuntimeError):
+    """Not enough Slurm tasks to start all required processes."""
+
+
+class SlurmRunner(BaseRunner):
+    def __init__(self, *args, **kwargs):
+        try:
+            self.rank = int(os.environ["SLURM_PROCID"])
+            self.world_size = self.n_workers = int(os.environ["SLURM_NTASKS"])
+        except KeyError as e:
+            raise RuntimeError("SLURM_PROCID and SLURM_NTASKS must be present "
+                               "in the environment."
+                               ) from e
+
+        super().__init__(*args, **kwargs)
+
+    async def get_role(self) -> str:
+        if self.scheduler and self.client and self.world_size < 3:
+            raise WorldTooSmallException(
+                f"Not enough Slurm tasks to start cluster, found {self.world_size}, "
+                "needs at least 3, one each for the scheduler, client and a worker."
+            )
+        elif self.scheduler and self.world_size < 2:
+            raise WorldTooSmallException(
+                f"Not enough Slurm tasks to start cluster, found {self.world_size}, "
+                "needs at least 2, one each for the scheduler and a worker."
+            )
+        self.n_workers -= int(self.scheduler) + int(self.client)
+        if self.rank == 0 and self.scheduler:
+            return Role.scheduler
+        elif self.rank == 1 and self.client:
+            return Role.client
+        else:
+            return Role.worker
+
+    async def set_scheduler_address(self, scheduler: Scheduler) -> None:
+        return
+
+    async def get_scheduler_address(self) -> str:
+        return
+
+    async def on_scheduler_start(self, scheduler: Scheduler) -> None:
+        return
+
+    async def before_worker_start(self) -> None:
+        return
+
+    async def before_client_start(self) -> None:
+        return
+
+    async def get_worker_name(self) -> str:
+        return self.rank
+
+    async def _close(self):
+        await super()._close()
+
+
+def initialize(
+    interface=None,
+    nthreads=1,
+    local_directory="",
+    memory_limit="auto",
+    nanny=False,
+    dashboard=True,
+    dashboard_address=":8787",
+    protocol=None,
+    worker_class="distributed.Worker",
+    worker_options=None,
+    scheduler_file="scheduler.json",
+):
+    """
+    Initialize a Dask cluster using Slurm
+
+    Using Slurm, the user launches 3 or more tasks, usually with the 'srun' command.
+    The first task becomes the scheduler, the second task becomes the client, and the
+    remaining tasks become workers.  Each task identifies its task ID using the
+    'SLURM_PROCID' environment variable, which is like the MPI rank.  The scheduler
+    address is communicated using the 'scheduler_file' keyword argument.
+
+    Parameters
+    ----------
+    interface : str
+        Network interface like 'eth0' or 'ib0'
+    nthreads : int
+        Number of threads per worker
+    local_directory : str
+        Directory to place worker files
+    memory_limit : int, float, or 'auto'
+        Number of bytes before spilling data to disk.  This can be an
+        integer (nbytes), float (fraction of total memory), or 'auto'.
+    nanny : bool
+        Start workers in nanny process for management (deprecated, use worker_class instead)
+    dashboard : bool
+        Enable Bokeh visual diagnostics
+    dashboard_address : str
+        Bokeh port for visual diagnostics
+    protocol : str
+        Protocol like 'inproc' or 'tcp'
+    worker_class : str
+        Class to use when creating workers
+    worker_options : dict
+        Options to pass to workers
+    scheduler_file : str
+        Filename to use when saving scheduler connection information
+    """
+
+    scheduler_options = {
+        "interface": interface,
+        "protocol": protocol,
+        "dashboard": dashboard,
+        "dashboard_address": dashboard_address,
+        "scheduler_file": scheduler_file,
+    }
+    worker_options = {
+        "interface": interface,
+        "protocol": protocol,
+        "nthreads": nthreads,
+        "memory_limit": memory_limit,
+        "local_directory": local_directory,
+        "scheduler_file": scheduler_file,
+    }
+    worker_class = "dask.distributed.Nanny" if nanny else "dask.distributed.Worker"
+    runner = SlurmRunner(
+        scheduler_options=scheduler_options,
+        worker_class=worker_class,
+        worker_options=worker_options,
+    )
+    dask.config.set(scheduler_file=scheduler_file)
+    _RUNNER_REF = runner  # Keep a reference to avoid gc
+    atexit.register(_RUNNER_REF.close)
+    return runner

--- a/dask_hpc_runner/tests/slurm_core_context.py
+++ b/dask_hpc_runner/tests/slurm_core_context.py
@@ -2,8 +2,7 @@ from dask.distributed import Client
 from dask_hpc_runner import  SlurmRunner
 
 with SlurmRunner(
-    scheduler_options={"scheduler_file":"scheduler.json"},
-    worker_options={"scheduler_file":"scheduler.json"},
+    scheduler_file="scheduler.json",
 ) as runner:
     with Client(scheduler_file="scheduler.json") as client:
         assert client.submit(lambda x: x + 1, 10).result() == 11

--- a/dask_hpc_runner/tests/slurm_core_context.py
+++ b/dask_hpc_runner/tests/slurm_core_context.py
@@ -1,0 +1,10 @@
+from dask.distributed import Client
+from dask_hpc_runner import  SlurmRunner
+
+with SlurmRunner(
+    scheduler_options={"scheduler_file":"scheduler.json"},
+    worker_options={"scheduler_file":"scheduler.json"},
+) as runner:
+    with Client(scheduler_file="scheduler.json") as client:
+        assert client.submit(lambda x: x + 1, 10).result() == 11
+        assert client.submit(lambda x: x + 1, 20, workers=2).result() == 21

--- a/dask_hpc_runner/tests/slurm_core_context.py
+++ b/dask_hpc_runner/tests/slurm_core_context.py
@@ -1,9 +1,7 @@
 from dask.distributed import Client
 from dask_hpc_runner import  SlurmRunner
 
-with SlurmRunner(
-    scheduler_file="scheduler.json",
-) as runner:
-    with Client(scheduler_file="scheduler.json") as client:
+with SlurmRunner() as runner:
+    with Client(runner) as client:
         assert client.submit(lambda x: x + 1, 10).result() == 11
         assert client.submit(lambda x: x + 1, 20, workers=2).result() == 21

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+
+
+def test_context(srun):
+    script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
+
+    p = subprocess.Popen(srun + ["-n", "4", sys.executable, script_file])
+
+    p.communicate()
+    assert p.returncode == 0
+
+
+def test_small_world(srun):
+    script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
+
+    p = subprocess.Popen(srun + ["-n", "1", sys.executable, script_file], stderr=subprocess.PIPE)
+
+    _, std_err = p.communicate()
+    assert p.returncode != 0
+    assert "Not enough Slurm tasks" in std_err.decode(sys.getfilesystemencoding())


### PR DESCRIPTION
This is a proof-of-concept of a `SlurmRunner`, following the idea of `MPIRunner`. Slurm tasks identify their "rank" with the `SLURM_PROCID` environment variable, and the scheduler address is handled by the scheduler file. Addresses #1.

In particular, because workers/clients/schedulers already know how to deal with scheduler files, I think(?) there's no reason the `SlurmRunner` needs to open the file or set a `scheduler_address`. This implementation just passes the scheduler file through. I could be wrong though, happy to revisit this. The API could be improved, too; right now `scheduler_file="scheduler.json"` has to be specified in a few places.

One possible problem with the currently implementation is that it doesn't wait for the scheduler to start before starting the client and workers (no MPI barrier). I'm not sure if this is allowed in dask. Do clients and workers have a retry mechanism, or will they fail if the scheduler hasn't started yet? I may have seen hangs because of this.

Also, shutdown isn't graceful yet; the scheduler/workers stay alive even after the client disconnects. I didn't look to me like shutdown was graceful in `MPIRunner` yet either (it just issues an `MPI_ABORT`), so I figured this was WIP.

Despite these problems, the basic idea seems to work.