### PR TITLE
SLURM improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,11 +6,11 @@ on:
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
-    
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     services:
         # Add a mysql databse for SLURM to use
         mysql:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,3 +36,6 @@ jobs:
         run: pipx install hatch
       - name: Run tests
         run: hatch run test:run
+      - name: Debug SLURM queue
+        if: always()
+        run: squeue

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: mpi4py/setup-mpi@v1
       - name: Setup SLURM
         uses: koesterlab/setup-slurm-action@v1
+      - name: Print SLURM info
+        run: sinfo -Nel
       - name: Install hatch
         run: pipx install hatch
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+scheduler-*.json

--- a/dask_hpc_runner/base.py
+++ b/dask_hpc_runner/base.py
@@ -180,10 +180,16 @@ class BaseRunner(SyncMethodMixin):
     async def _close(self) -> None:
         print(f"stopping {self.role}")
         if self.status == Status.running:
+            print("Terminating scheduler")
             if self.scheduler_comm:
+                print("Scheduler connected, closing")
                 with suppress(CommClosedError):
                     await self.scheduler_comm.terminate()
+                    print("Terminated")
+            else:
+                print("No connection to scheduler, unable to terminate")
             self.status = Status.closed
+        print(f"{self.role} stopped")
 
     def close(self) -> None:
         return self.sync(self._close)

--- a/dask_hpc_runner/slurm.py
+++ b/dask_hpc_runner/slurm.py
@@ -18,7 +18,7 @@ class WorldTooSmallException(RuntimeError):
 class SlurmRunner(BaseRunner):
     def __init__(self, *args, scheduler_file="scheduler-{}.json", **kwargs):
         try:
-            self.rank = int(os.environ["SLURM_PROCID"])
+            self.proc_id = int(os.environ["SLURM_PROCID"])
             self.world_size = self.n_workers = int(os.environ["SLURM_NTASKS"])
             self.job_id = int(os.environ["SLURM_JOB_ID"])
         except KeyError as e:
@@ -63,9 +63,9 @@ class SlurmRunner(BaseRunner):
                 "needs at least 2, one each for the scheduler and a worker."
             )
         self.n_workers -= int(self.scheduler) + int(self.client)
-        if self.rank == 0 and self.scheduler:
+        if self.proc_id == 0 and self.scheduler:
             return Role.scheduler
-        elif self.rank == 1 and self.client:
+        elif self.proc_id == 1 and self.client:
             return Role.client
         else:
             return Role.worker
@@ -83,7 +83,7 @@ class SlurmRunner(BaseRunner):
         return
 
     async def get_worker_name(self) -> str:
-        return self.rank
+        return self.proc_id
 
     async def _close(self):
         await super()._close()

--- a/dask_hpc_runner/tests/slurm_core_context.py
+++ b/dask_hpc_runner/tests/slurm_core_context.py
@@ -1,5 +1,5 @@
 from dask.distributed import Client
-from dask_hpc_runner import  SlurmRunner
+from dask_hpc_runner import SlurmRunner
 
 with SlurmRunner() as runner:
     with Client(runner) as client:

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -2,7 +2,10 @@ import os
 import subprocess
 import sys
 
+import pytest
 
+
+@pytest.mark.timeout(10)
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
@@ -12,6 +15,7 @@ def test_context(srun):
     assert p.returncode == 0
 
 
+@pytest.mark.timeout(10)
 def test_small_world(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -2,10 +2,6 @@ import os
 import subprocess
 import sys
 
-import pytest
-
-pytest.skip(allow_module_level=True)  # Skip SLURM tests which are currently hanging
-
 
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -9,7 +9,7 @@ import pytest
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
-    p = subprocess.Popen(srun + ["-n", "4", sys.executable, script_file])
+    p = subprocess.Popen(srun + ["-n", "4", "--ntasks-per-node", "4", sys.executable, script_file])
 
     p.communicate()
     assert p.returncode == 0
@@ -19,7 +19,9 @@ def test_context(srun):
 def test_small_world(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
-    p = subprocess.Popen(srun + ["-n", "1", sys.executable, script_file], stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        srun + ["-n", "1", "--ntasks-per-node", "1", sys.executable, script_file], stderr=subprocess.PIPE
+    )
 
     _, std_err = p.communicate()
     assert p.returncode != 0

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -6,12 +6,11 @@ import pytest
 
 
 @pytest.mark.timeout(10)
+@pytest.mark.skipif(os.cpu_count() < 4, reason="Need at least 4 CPUs to run this test")
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
-    p = subprocess.Popen(
-        srun + ["-vvvv", "-n", "4", "--ntasks-per-node", "4", "--time=00:01:00", sys.executable, script_file]
-    )
+    p = subprocess.Popen(srun + ["-vvvv", "-n", "4", sys.executable, script_file])
 
     p.communicate()
     assert p.returncode == 0
@@ -22,7 +21,7 @@ def test_small_world(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
     p = subprocess.Popen(
-        srun + ["-vvvv", "-n", "1", "--ntasks-per-node", "1", "--time=00:01:00", sys.executable, script_file],
+        srun + ["-vvvv", "-n", "1", sys.executable, script_file],
         stderr=subprocess.PIPE,
     )
 

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -9,7 +9,7 @@ import pytest
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
-    p = subprocess.Popen(srun + ["-n", "4", "--ntasks-per-node", "4", sys.executable, script_file])
+    p = subprocess.Popen(srun + ["-vvvv", "-n", "4", "--ntasks-per-node", "4", sys.executable, script_file])
 
     p.communicate()
     assert p.returncode == 0
@@ -20,7 +20,7 @@ def test_small_world(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
     p = subprocess.Popen(
-        srun + ["-n", "1", "--ntasks-per-node", "1", sys.executable, script_file], stderr=subprocess.PIPE
+        srun + ["-vvvv", "-n", "1", "--ntasks-per-node", "1", sys.executable, script_file], stderr=subprocess.PIPE
     )
 
     _, std_err = p.communicate()

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -5,8 +5,13 @@ import sys
 import pytest
 
 
+def slurm_cores():
+    "Use sinfo to get the number of available CPU cores"
+    return int(subprocess.check_output(["sinfo", "-o", "%C"]).split()[1].decode().split("/")[1])
+
+
 @pytest.mark.timeout(10)
-@pytest.mark.skipif(os.cpu_count() < 4, reason="Need at least 4 CPUs to run this test")
+@pytest.mark.skipif(slurm_cores() < 4, reason="Need at least 4 CPUs to run this test")
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 

--- a/dask_hpc_runner/tests/test_slurm.py
+++ b/dask_hpc_runner/tests/test_slurm.py
@@ -9,7 +9,9 @@ import pytest
 def test_context(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
-    p = subprocess.Popen(srun + ["-vvvv", "-n", "4", "--ntasks-per-node", "4", sys.executable, script_file])
+    p = subprocess.Popen(
+        srun + ["-vvvv", "-n", "4", "--ntasks-per-node", "4", "--time=00:01:00", sys.executable, script_file]
+    )
 
     p.communicate()
     assert p.returncode == 0
@@ -20,7 +22,8 @@ def test_small_world(srun):
     script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "slurm_core_context.py")
 
     p = subprocess.Popen(
-        srun + ["-vvvv", "-n", "1", "--ntasks-per-node", "1", sys.executable, script_file], stderr=subprocess.PIPE
+        srun + ["-vvvv", "-n", "1", "--ntasks-per-node", "1", "--time=00:01:00", sys.executable, script_file],
+        stderr=subprocess.PIPE,
     )
 
     _, std_err = p.communicate()


### PR DESCRIPTION
- Exclude scheduler files from version control
- Move waiting for the scheduler file to when we get the scheduler address.
- Use a signal to close the processes as this avoids the hangs I was seeing with `sys.exit()` xref https://github.com/dask/distributed/issues/8644
- Rename `SLURMRunner.rank` to `SLURMRunner.proc_id` to be more in line with SLURM terminology